### PR TITLE
Small Bug Fix + Invoke subprocesses via Python.

### DIFF
--- a/smoothie.py
+++ b/smoothie.py
@@ -1,8 +1,8 @@
 from argparse import ArgumentParser
-from sys import argv,exit
+from sys import argv, exit
 from os import path, system
 from configparser import ConfigParser
-from subprocess import run
+from subprocess import run, Popen, PIPE
 from random import choice # Randomize smoothie's flavor
 
 # Bool aliases
@@ -119,10 +119,9 @@ for video in args.input: # Loops through every single video
         vpy = path.abspath(path.join(path.dirname(__file__),'blender.vpy'))
     
     command = [ # This is the master command, it gets appended some extra output args later down
-    f'{vspipe} -y "{vpy}" --arg input_video="{video}" --arg config_filepath="{config_filepath}" ',
-    f'- | {conf["encoding"]["process"]} -hide_banner -loglevel warning -stats -i - ',
+    f'{vspipe} -y "{vpy}" --arg input_video="{path.abspath(video)}" --arg config_filepath="{config_filepath}" -',
+    f'{conf["encoding"]["process"]} -hide_banner -loglevel warning -stats -i - '
     ]
-
     if args.peek:
         frame = int(args.peek[0]) # Extracting the frame passed from the singular array
         command[0] += f'--start {frame} --end {frame}'
@@ -139,6 +138,6 @@ for video in args.input: # Loops through every single video
         for cmd in command: print(cmd)
         print(f"Queuing video: {video}")
 
-    run(' '.join(command),shell=True)
+    run(command[1], stdin = Popen(command[0], stdout = PIPE).stdout)
 
 system(f"title [{round}/{len(args.input)}] Smoothie - Finished! (EOF)")


### PR DESCRIPTION
1. Fixed a bug where Smoothie wasn't converting input videos into their absolute paths. 
2. Instead of using "shell = True" to pipe input into ffmpeg from vspipe, pipe using python itself.

### Why did you remove `shell = True`?
You can invoke a process in 2 ways in Python either using the system shell (`shell = True`) or via Python itself.
Using `shell = True` can open access to the system shell entirely and if a user somehow access to the `run/Popen` with `shell = True`, they can execute shell commands which can compromise security of the program itself. 
In the case of Smoothie, this access to the system shell is via this config value:
```ini
[encoding]
process=ffmpeg
args=-c:v hevc_nvenc -rc constqp -preset p7 -qp 18
````

Say we set up the value like this:
```ini
[encoding]
process=ffmpeg
args=-c:v hevc_nvenc -rc constqp -preset p7 -qp 18 | dir && echo "Hello from shell = True!" && pause
```

With `shell = True`:
https://user-images.githubusercontent.com/41850963/158943894-3b4782d2-13b2-4ff4-babf-4dee4d494ff9.mp4

Using Python to pipe:
https://user-images.githubusercontent.com/41850963/158944319-0ecf65f6-937c-472f-8fef-32c65d08e0f8.mp4




